### PR TITLE
Fix reward computing issue by picking the latest protein-like string

### DIFF
--- a/sequence_design/acqfs.py
+++ b/sequence_design/acqfs.py
@@ -56,7 +56,8 @@ class Acqf(RewardModelTemplate):
         self.embedder.unload()
 
     def post_process(self, generation):
-        return re.findall("[A-Z]{230,}", generation)[0]
+        # Pick the lastest protein-like sequence
+        return re.findall("[A-Z]{230,}", generation)[-1]
 
 
 class qKG(Acqf):


### PR DESCRIPTION
In this PR, I fix the reward computing issue. Previously, the code picks the first protein-like string in the entire conversation. However, computing reward should be done for the latest generated protein so that this PR fixes that issue.